### PR TITLE
Fallback to constructor-specified properties in `unobserve`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -96,6 +96,11 @@ export default class StyleObserver {
 			return;
 		}
 
+		if (properties.length === 0) {
+			// Default to constructor-specified properties
+			properties = this.options.properties;
+		}
+
 		for (let target of targets) {
 			let observer = this.elementObservers.get(target);
 


### PR DESCRIPTION
Otherwise, we might never remove event listeners for the `transitionstart` event and probably face other issues.
<!-- GitButler Review Footer Boundary Top -->
---
⧓ Review in [Butler Review `#9lmac7j8k`](https://gitbutler.com/dmitrysharabin/prismjs-plugins/reviews/9lmac7j8k)

**Plugins registery**


14 commit series (version 9)

| Series | Commit Title | Status | Reviewers | 
| --- | --- | --- | --- |
| 14/14 | [npm update](https://gitbutler.com/dmitrysharabin/prismjs-plugins/reviews/9lmac7j8k/commit/62e980da-5685-4bc0-87db-2fe43e9a01a2) | ⏳ |  |
| 13/14 | [Add type to `config`](https://gitbutler.com/dmitrysharabin/prismjs-plugins/reviews/9lmac7j8k/commit/b78eb1f8-e6a2-46a0-bdb5-7d3193af6433) | ⏳ |  |
| 12/14 | [Use safe `md`](https://gitbutler.com/dmitrysharabin/prismjs-plugins/reviews/9lmac7j8k/commit/b3e516b5-4a4d-4a17-9e3f-bce24817a5e3) | ⏳ |  |
| 11/14 | [Ditch unnecessary filter](https://gitbutler.com/dmitrysharabin/prismjs-plugins/reviews/9lmac7j8k/commit/c0b1f585-e917-458f-9e99-701a382de1bf) | ⏳ |  |
| 10/14 | [Use markdown and `md` filter](https://gitbutler.com/dmitrysharabin/prismjs-plugins/reviews/9lmac7j8k/commit/eb795e63-41d3-4998-a70b-ff1d8502b4e7) | ⏳ |  |
| 9/14 | [Address feedback: Improve readability](https://gitbutler.com/dmitrysharabin/prismjs-plugins/reviews/9lmac7j8k/commit/166d6c34-30fc-497b-ba4c-7c4a94d1fd1d) | ⏳ |  |
| 8/14 | [Oops](https://gitbutler.com/dmitrysharabin/prismjs-plugins/reviews/9lmac7j8k/commit/4a0720f3-bc05-4c44-964f-732fd0f91094) | ⏳ |  |
| 7/14 | [Address feedback: Simplify code](https://gitbutler.com/dmitrysharabin/prismjs-plugins/reviews/9lmac7j8k/commit/3b2b462b-10e0-4070-a548-578129a2b30b) | ⏳ |  |
| 6/14 | [Move metadata to READMEs for real](https://gitbutler.com/dmitrysharabin/prismjs-plugins/reviews/9lmac7j8k/commit/231a3ee4-6a63-4492-8c66-ba3580f2cd79) | ⏳ |  |
| 5/14 | [Generate `plugins.json` on build time](https://gitbutler.com/dmitrysharabin/prismjs-plugins/reviews/9lmac7j8k/commit/3d58ed31-1bb1-45ab-8916-11498992ac1a) | ⏳ |  |
| 4/14 | [Gather all plugins in the plugin collection using tags](https://gitbutler.com/dmitrysharabin/prismjs-plugins/reviews/9lmac7j8k/commit/d56f40af-9868-4c3e-a2f3-b8c836ccaeb7) | ⏳ |  |
| 3/14 | [Add the `escape_quotes` filter](https://gitbutler.com/dmitrysharabin/prismjs-plugins/reviews/9lmac7j8k/commit/6a364367-bc02-48f6-a493-51a28704544a) | ⏳ |  |
| 2/14 | [Move plugin metadata to READMEs](https://gitbutler.com/dmitrysharabin/prismjs-plugins/reviews/9lmac7j8k/commit/52a1205b-1eff-41eb-9562-78e94a64b38b) | ⏳ |  |
| 1/14 | [Separate the plugin registry from other Prism components](https://gitbutler.com/dmitrysharabin/prismjs-plugins/reviews/9lmac7j8k/commit/f1a14788-68d9-4723-b482-4803e2d9f86a) | ⏳ |  |

_Please leave review feedback in the [Butler Review](https://gitbutler.com/dmitrysharabin/prismjs-plugins/reviews/9lmac7j8k)_
<!-- GitButler Review Footer Boundary Bottom -->
