### PR TITLE
[tests] Download `htest.js` after the page with tests is fully rendered

### DIFF
--- a/tests/index.html
+++ b/tests/index.html
@@ -5,8 +5,7 @@
 	<meta charset="UTF-8">
 	<title>Tests</title>
 	<link rel="stylesheet" href="https://htest.dev/htest.css" crossorigin />
-	<script src="https://htest.dev/htest.js" type="module" crossorigin></script>
-	<script>
+	<script type="module">
 		let params = new URLSearchParams(location.search);
 		let test_url = params.get("test");
 
@@ -21,7 +20,7 @@
 				test_url = `./${test_url}`;
 			}
 
-			Promise.all([
+			await Promise.all([
 				import("https://htest.dev/src/render.js").then(m => m.default),
 				import(test_url).then(m => m.default),
 			]).then(([render, test]) => render(test));
@@ -30,7 +29,7 @@
 			document.documentElement.classList.add("index");
 
 			// Index of all tests
-			fetch("./index.json").then(r => r.json()).then(index => {
+			await fetch("./index.json").then(r => r.json()).then(index => {
 				index = Object.entries(index).map(([id, name]) => ({ id, name }));
 
 				document.body.innerHTML = `
@@ -48,6 +47,8 @@
 				`;
 			});
 		}
+
+		import("https://htest.dev/htest.js");
 	</script>
 </head>
 


### PR DESCRIPTION
Since we generate the tests on the fly, we need to make sure `htest.js` has something to work with (e.g., sections with tests). This lets us use the HTML-first mode of hTest to its full potential (tests navigation, isolation, etc). All those features will make debugging so much easier! However, we need [this PR](https://github.com/htest-dev/htest/pull/72) to be merged first.