### PR TITLE
Correctly handle falsy initial values

### DIFF
--- a/src/util/gentle-register-property.js
+++ b/src/util/gentle-register-property.js
@@ -18,7 +18,7 @@ export default function gentleRegisterProperty (property, meta = {}) {
 			inherits: meta.inherits ?? true,
 		};
 
-		if (meta.initialValue) {
+		if (meta.initialValue !== undefined) {
 			definition.initialValue = meta.initialValue;
 		}
 


### PR DESCRIPTION
For now, initial values like `0` or `""` are not set, and `CSS.registerProperty()` might throw, e.g., in Firefox.