### PR TITLE
[util] Take into account transitions starting with custom properties

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -75,7 +75,7 @@ export function getTimesFor (property, transitions) {
 	else {
 		let properties = getLonghands(property);
 		properties.push("all");
-		propertyRegex = RegExp(`(?<![\\w-])(${ properties.join("|") })\\b`);
+		propertyRegex = RegExp(`(?<=^|\\s)(${ properties.join("|") })\\b`);
 	}
 
 	let lastRelevantTransition = transitions.findLast(transition => propertyRegex.test(transition));


### PR DESCRIPTION
`\b` doesn't include `-` custom properties start with.