### PR TITLE
[util] Improve property registration

### DIFF
--- a/src/util/gentle-register-property.js
+++ b/src/util/gentle-register-property.js
@@ -9,11 +9,11 @@ const INITIAL_VALUES = {
 	"<number>": "0",
 	"<percentage>": "0%",
 	"<resolution>": "1dppx",
-	"<string>": '""',
+	"<string>": "''",
 	"<time>": "0s",
-	"<transform-function>": "none",
-	"<transform-list>": "none",
-	"<url>": "none",
+	"<transform-function>": "scale(1)",
+	"<transform-list>": "scale(1)",
+	"<url>": "url('')",
 };
 
 /**


### PR DESCRIPTION
~Depends on #40.~

- Workaround [the bug with an initial value of the custom property of syntax `<string>`](https://github.com/LeaVerou/style-observer/issues/42#issuecomment-2637610674)
- Try registering custom properties of not supported syntax with the universal syntax