### PR TITLE
Extend support for older browsers

### DIFF
--- a/src/util/adopt-css.js
+++ b/src/util/adopt-css.js
@@ -4,7 +4,12 @@ export default function adoptCSS (css) {
 	if (document.adoptedStyleSheets) {
 		let sheet = new CSSStyleSheet();
 		sheet.replaceSync(css);
-		document.adoptedStyleSheets.push(sheet);
+		if (Object.isFrozen(document.adoptedStyleSheets)) {
+			document.adoptedStyleSheets = [...document.adoptedStyleSheets, sheet];
+		}
+		else {
+			document.adoptedStyleSheets.push(sheet);
+		}
 	}
 	else {
 		style ??= document.head.appendChild(document.createElement("style"));


### PR DESCRIPTION
` document.adoptedStyleSheets.push(sheet)` might cause `TypeError: Cannot add property 0, object is not extensible`