### PR TITLE
TypeDoc tweaks

### DIFF
--- a/typedoc.json
+++ b/typedoc.json
@@ -12,4 +12,12 @@
 	"entryPointStrategy": "expand",
 	"excludeExternals": true,
 	"includeVersion": true,
+	"markdownItOptions": {
+		"html": true,
+		"linkify": true,
+		"typographer": true
+	},
+	"favicon": "assets/logo.svg",
+	"hostedBaseUrl": "https://observe.style/api",
+	"readme": "none"
 }


### PR DESCRIPTION
- Show the list of modules instead of README
- Use markdown-it typographer when generating docs from comments
- Add favicon and base URL