### PR TITLE
[tests] First stab at testing layout recalculation (reflow) on property observation

### DIFF
--- a/tests/index-fn.js
+++ b/tests/index-fn.js
@@ -10,6 +10,7 @@ let tests = await Promise.all([
 	"change",
 	"transition",
 	"util",
+	"reflow",
 ].map(name => import(`./${name}.js`).then(module => module.default)));
 
 

--- a/tests/index.json
+++ b/tests/index.json
@@ -9,5 +9,6 @@
 	"records": "Number of records",
 	"change": "Property change",
 	"transition": "The transition property",
-	"util": "Utility functions"
+	"util": "Utility functions",
+	"reflow": "Reflow (layout recalculation)"
 }

--- a/tests/reflow.js
+++ b/tests/reflow.js
@@ -16,6 +16,17 @@ export default {
 			iframe.contentDocument.body.append(dummy);
 		}
 
+		iframe.contentDocument.head.insertAdjacentHTML(
+			"beforeend",
+			`<style>
+				@property --registered-custom-property {
+					syntax: "<number>";
+					inherits: true;
+					initial-value: 1;
+				}
+			</style>`,
+		);
+
 		this.iframe = iframe;
 	},
 
@@ -82,6 +93,10 @@ export default {
 					args: ["--custom-property", "bar"],
 					expect: [false, "bar"],
 					skip: true,
+				},
+				{
+					args: ["--registered-custom-property", 42],
+					expect: [false, "42"],
 				},
 				{
 					args: ["color", "red"],

--- a/tests/reflow.js
+++ b/tests/reflow.js
@@ -1,0 +1,116 @@
+import StyleObserver from "../index.js";
+
+export default {
+	name: "Reflow (layout recalculation)",
+
+	beforeEach () {
+		let iframe = document.createElement("iframe");
+		document.body.append(iframe);
+
+		for (let i = 0; i < 2; i++) {
+			let dummy = Object.assign(document.createElement("div"), {
+				textContent: "Style Observer Test",
+				style: "--custom-property: foo;",
+			});
+
+			iframe.contentDocument.body.append(dummy);
+		}
+
+		this.iframe = iframe;
+	},
+
+	run (property, value) {
+		let target = this.iframe.contentDocument.body.children[0];
+
+		let styleObserver;
+		let stylePromise = new Promise(resolve => {
+			styleObserver = new StyleObserver(records => resolve(records[0]), {
+				target,
+				properties: [property],
+			});
+
+			styleObserver.observe();
+
+			setTimeout(resolve, 300, {});
+		}).finally(() => {
+			styleObserver.unobserve();
+		});
+
+		let reflowObserver;
+		let reflowPromise = new Promise(resolve => {
+			reflowObserver = new this.iframe.contentWindow.PerformanceObserver(list => {
+				for (let entry of list.getEntries()) {
+					console.log(
+						`Reflow detected: ${entry.startTime}ms, duration: ${entry.duration}ms`,
+					);
+
+					let sources = entry.sources.map(source => source.node.nodeName);
+					console.log(`Source(s): ${sources.join(", ")}`);
+
+					resolve(true);
+				}
+			});
+
+			reflowObserver.observe({ type: "layout-shift" });
+
+			setTimeout(resolve, 300, false);
+		}).finally(() => {
+			reflowObserver.disconnect();
+		});
+
+		setTimeout(() => {
+			target.style.setProperty(property, value);
+		}, 50);
+
+		return Promise.all([reflowPromise, stylePromise]).then(([reflow, change]) => [
+			reflow,
+			change.value,
+		]);
+	},
+
+	afterEach () {
+		this.iframe.remove();
+	},
+
+	tests: [
+		{
+			name: "Properties not causing reflow",
+			description:
+				"Check whether observing a CSS property does not cause reflow (layout recalculation).",
+			tests: [
+				{
+					args: ["--custom-property", "bar"],
+					expect: [false, "bar"],
+					skip: true,
+				},
+				{
+					args: ["color", "red"],
+					expect: [false, "rgb(255, 0, 0)"],
+				},
+				{
+					args: ["visibility", "hidden"],
+					expect: [false, "hidden"],
+				},
+			],
+		},
+		{
+			name: "Properties causing reflow",
+			description:
+				"Don't skip these tests to make sure that changing a CSS property causes reflow (layout recalculation)",
+			tests: [
+				{
+					args: ["height", "100px"],
+					expect: [true, "100px"],
+				},
+				{
+					args: ["position", "absolute"],
+					expect: [true, "absolute"],
+				},
+				{
+					args: ["text-align", "center"],
+					expect: [true, "center"],
+				},
+			],
+		},
+	],
+};


### PR DESCRIPTION
This approach [has limited support](https://caniuse.com/?search=layoutshift) (~76% of global users). For now, Safari and Firefox are not supported at all.

However, these tests help answer whether observing properties causes reflow — No. 🙂

And we probably have one more issue to solve — observing custom properties in `<iframe>` seems not working (I need to test it more thoroughly).

**UPDATE:** Not registered custom properties seem to be not being observed.

https://deploy-preview-73--style-observer.netlify.app/tests/?test=reflow

<img width="1326" alt="image" src="https://github.com/user-attachments/assets/03a866e4-cc65-40d1-bbbf-1c8eeed02772" />
