### PR TITLE
Attempt to fix #77

### DIFF
--- a/tests/change.js
+++ b/tests/change.js
@@ -1,5 +1,5 @@
 import StyleObserver from "../index.js";
-import gentleRegisterProperty from "../src/util/gentle-register-property.js";
+import gentleRegisterProperty from "./util/gentle-register-property.js";
 import adoptCss from "../src/util/adopt-css.js";
 
 

--- a/tests/multiple.js
+++ b/tests/multiple.js
@@ -1,5 +1,5 @@
 import StyleObserver from "../index.js";
-import gentleRegisterProperty from "../src/util/gentle-register-property.js";
+import gentleRegisterProperty from "./util/gentle-register-property.js";
 
 export default {
 	name: "Multiple observers on the same target",

--- a/tests/nested.js
+++ b/tests/nested.js
@@ -1,5 +1,5 @@
 import StyleObserver from "../index.js";
-import gentleRegisterProperty from "../src/util/gentle-register-property.js";
+import gentleRegisterProperty from "./util/gentle-register-property.js";
 
 let tests = [
 	{

--- a/tests/records.js
+++ b/tests/records.js
@@ -1,6 +1,6 @@
 import StyleObserver from "../index.js";
 import { wait } from "../src/util.js";
-import gentleRegisterProperty from "../src/util/gentle-register-property.js";
+import gentleRegisterProperty from "./util/gentle-register-property.js";
 import commonTests from "./tests.js";
 
 const TIMEOUT = 500;

--- a/tests/shadow.js
+++ b/tests/shadow.js
@@ -1,5 +1,5 @@
 import StyleObserver from "../index.js";
-import gentleRegisterProperty from "../src/util/gentle-register-property.js";
+import gentleRegisterProperty from "./util/gentle-register-property.js";
 import tests from "./tests.js";
 
 export default {

--- a/tests/syntax.js
+++ b/tests/syntax.js
@@ -1,5 +1,5 @@
 import StyleObserver from "../index.js";
-import gentleRegisterProperty from "../src/util/gentle-register-property.js";
+import gentleRegisterProperty from "./util/gentle-register-property.js";
 
 let initialData = {
 	angle: "0deg",

--- a/tests/util/gentle-register-property.js
+++ b/tests/util/gentle-register-property.js
@@ -16,7 +16,7 @@ export default function gentleRegisterProperty (property, meta = {}, global = gl
 	try {
 		global.CSS.registerProperty({
 			name: property,
-			inherits: true,
+			inherits: meta.inherits ?? true,
 			syntax: meta.syntax,
 			initialValue: meta.initialValue,
 		});

--- a/tests/util/properties.css
+++ b/tests/util/properties.css
@@ -1,0 +1,11 @@
+@property --any {
+	syntax: "*";
+	inherits: true;
+	initial-value: 0;
+}
+
+@property --color {
+	syntax: "<color>";
+	inherits: true;
+	initial-value: rgba(0, 0, 0, 0);
+}


### PR DESCRIPTION
Changes:

- Refactor `gentleRegisterProperty()` to use `@layer {}` + add [corresponding tests](https://deploy-preview-79--style-observer.netlify.app/tests/?test=util#gentleregisterproperty)
- Update existing tests to use `gentleRegisterProperty()` from `tests/util`
- Allow gentle registration of non-inherited properties in tests