### PR TITLE
[website] Style tweaks

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -57,6 +57,15 @@ main {
 	color: inherit;
 }
 
+:is(h1, h2, h3, h4) {
+	--factor: 3;
+	scroll-margin-block-start: calc(var(--wa-space-xl) * var(--factor));
+
+	@media (width <= 450px) {
+		--factor: 6;
+	}
+}
+
 h1 {
 	position: relative;
 	display: flex;

--- a/assets/style.css
+++ b/assets/style.css
@@ -165,6 +165,7 @@ aside {
 		text-decoration: none;
 		font-size: var(--wa-font-size-s);
 		font-weight: var(--wa-font-weight-semibold);
+		white-space: nowrap;
 	}
 }
 

--- a/assets/style.css
+++ b/assets/style.css
@@ -45,7 +45,6 @@ header, footer {
 }
 
 main {
-	grid-area: main;
 	max-width: var(--max-content-width);
 	padding: var(--wa-space-xl);
 	margin-inline-end: auto;
@@ -99,7 +98,6 @@ header {
 	z-index: 1;
 	display: flex;
 	align-items: center;
-	grid-area: header;
 	border-bottom: var(--wa-border-style) var(--wa-panel-border-width) var(--wa-color-surface-border);
 	padding-block: var(--wa-space-s);
 	background: var(--wa-color-surface-default);
@@ -143,7 +141,6 @@ nav {
 }
 
 aside {
-	grid-area: aside;
 	border-inline-end: var(--wa-border-style) var(--wa-panel-border-width) var(--wa-color-surface-border);
 	padding-block: var(--wa-space-l);
 	padding-inline: var(--wa-space-l);
@@ -201,7 +198,6 @@ main {
 }
 
 footer {
-	grid-area: footer;
 	border-top: var(--wa-border-style) var(--wa-panel-border-width) var(--wa-color-surface-border);
 }
 

--- a/assets/style.css
+++ b/assets/style.css
@@ -57,12 +57,7 @@ main {
 }
 
 :is(h1, h2, h3, h4) {
-	--factor: 3;
-	scroll-margin-block-start: calc(var(--wa-space-xl) * var(--factor));
-
-	@media (width <= 450px) {
-		--factor: 6;
-	}
+	scroll-margin-block-start: var(--header-height);
 }
 
 h1 {


### PR DESCRIPTION
- Add scroll margin to headings
- Remove leftovers from the previous grid layout

**Before** (I chose “Future Work“ in the nav)
<img width="852" alt="image" src="https://github.com/user-attachments/assets/73e13f2f-b0ed-4f28-abbc-7a40932aa09b" />


**After**
<img width="852" alt="image" src="https://github.com/user-attachments/assets/798d18f1-44d9-4ede-82a0-56093bcf7f44" />
