### PR TITLE
Another attempt to fix #91

### DIFF
--- a/src/element-style-observer.js
+++ b/src/element-style-observer.js
@@ -1,5 +1,4 @@
-import TRANSITIONRUN_EVENT_LOOP_BUG from "./util/detect-transitionrun-loop.js";
-import UNREGISTERED_TRANSITION_BUG from "./util/detect-unregistered-transition.js";
+import bugs from "./util/detect-bugs.js";
 import gentleRegisterProperty from "./util/gentle-register-property.js";
 import MultiWeakMap from "./util/MultiWeakMap.js";
 import { toArray, wait, getTimesFor } from "./util.js";
@@ -113,11 +112,14 @@ export default class ElementStyleObserver {
 			return;
 		}
 
-		if (TRANSITIONRUN_EVENT_LOOP_BUG && event.type === "transitionrun" || this.options.throttle > 0) {
-			let eventName = TRANSITIONRUN_EVENT_LOOP_BUG ? "transitionrun" : "transitionstart";
+		if (
+			(bugs.TRANSITIONRUN_EVENT_LOOP && event.type === "transitionrun") ||
+			this.options.throttle > 0
+		) {
+			let eventName = bugs.TRANSITIONRUN_EVENT_LOOP ? "transitionrun" : "transitionstart";
 			let delay = Math.max(this.options.throttle, 50);
 
-			if (TRANSITIONRUN_EVENT_LOOP_BUG) {
+			if (bugs.TRANSITIONRUN_EVENT_LOOP) {
 				// Safari < 18.2 fires `transitionrun` events too often, so we need to debounce.
 				// Wait at least the amount of time needed for the transition to run + 1 frame (~16ms)
 				let times = getTimesFor(event.propertyName, getComputedStyle(this.target).transition);
@@ -169,7 +171,7 @@ export default class ElementStyleObserver {
 		let cs = getComputedStyle(this.target);
 
 		for (let property of properties) {
-			if (UNREGISTERED_TRANSITION_BUG && !this.constructor.properties.has(property)) {
+			if (bugs.UNREGISTERED_TRANSITION && !this.constructor.properties.has(property)) {
 				// Init property
 				gentleRegisterProperty(property, undefined, this.target.ownerDocument.defaultView);
 				this.constructor.properties.add(property);
@@ -179,7 +181,7 @@ export default class ElementStyleObserver {
 			this.properties.set(property, value);
 		}
 
-		if (TRANSITIONRUN_EVENT_LOOP_BUG) {
+		if (bugs.TRANSITIONRUN_EVENT_LOOP) {
 			this.target.addEventListener("transitionrun", this);
 		}
 

--- a/src/util/detect-bugs.js
+++ b/src/util/detect-bugs.js
@@ -5,12 +5,10 @@ import UNREGISTERED_TRANSITION_BUG from "./detect-bugs/unregistered-transition.j
  * Data structure for all detected bugs.
  * All bugs start off as true, and once their promises resolve, that is replaced with the actual value
  */
-const bugs = {
+export const bugs = {
 	TRANSITIONRUN_EVENT_LOOP: true,
 	UNREGISTERED_TRANSITION: true,
 };
-
-export default bugs;
 
 TRANSITIONRUN_EVENT_LOOP_BUG.then(value => {
 	bugs.TRANSITIONRUN_EVENT_LOOP = value;
@@ -19,3 +17,7 @@ TRANSITIONRUN_EVENT_LOOP_BUG.then(value => {
 UNREGISTERED_TRANSITION_BUG.then(value => {
 	bugs.UNREGISTERED_TRANSITION = value;
 });
+
+export { TRANSITIONRUN_EVENT_LOOP_BUG, UNREGISTERED_TRANSITION_BUG };
+export const detected = Promise.all([TRANSITIONRUN_EVENT_LOOP_BUG, UNREGISTERED_TRANSITION_BUG]);
+export default bugs;

--- a/src/util/detect-bugs.js
+++ b/src/util/detect-bugs.js
@@ -1,0 +1,21 @@
+import TRANSITIONRUN_EVENT_LOOP_BUG from "./detect-bugs/transitionrun-loop.js";
+import UNREGISTERED_TRANSITION_BUG from "./detect-bugs/unregistered-transition.js";
+
+/**
+ * Data structure for all detected bugs.
+ * All bugs start off as true, and once their promises resolve, that is replaced with the actual value
+ */
+const bugs = {
+	TRANSITIONRUN_EVENT_LOOP: true,
+	UNREGISTERED_TRANSITION: true,
+};
+
+export default bugs;
+
+TRANSITIONRUN_EVENT_LOOP_BUG.then(value => {
+	bugs.TRANSITIONRUN_EVENT_LOOP = value;
+});
+
+UNREGISTERED_TRANSITION_BUG.then(value => {
+	bugs.UNREGISTERED_TRANSITION = value;
+});

--- a/src/util/detect-bugs/transitionrun-loop.js
+++ b/src/util/detect-bugs/transitionrun-loop.js
@@ -9,9 +9,9 @@ dummy.style.cssText = `${property}: 1; transition: ${property} 1ms step-start al
 /**
  * Detect if the browser is affected by the Safari transition loop bug.
  * @see https://bugs.webkit.org/show_bug.cgi?id=279012
- * @type {boolean}
+ * @type {Promise<boolean>}
  */
-export default await new Promise(resolve => {
+export default new Promise(resolve => {
 	let eventsCount = 0;
 	requestAnimationFrame(() => {
 		setTimeout(_ => resolve(eventsCount > 1), 50);

--- a/src/util/detect-bugs/unregistered-transition.js
+++ b/src/util/detect-bugs/unregistered-transition.js
@@ -7,9 +7,9 @@ dummy.style.cssText = `${property}: 1; transition: ${property} 1ms step-start al
 /**
  * Detect if the browser is affected by the unregistered transition bug.
  * @see https://issues.chromium.org/issues/360159391
- * @type {boolean}
+ * @type {Promise<boolean>}
  */
-export default await new Promise(resolve => {
+export default new Promise(resolve => {
 	requestAnimationFrame(() => {
 		setTimeout(_ => resolve(true), 30);
 		dummy.addEventListener("transitionstart", _ => resolve(false));


### PR DESCRIPTION
This contains the resolution logic in a summary module (`detect-bugs.js`) which sets `true` to both bugs and replaces it with actual values once the promises resolve. It also exports the actual promises and a summary promise, so that using code can choose to await that.

This is still prone to race conditions but at least the workaround is contained within this module, and by assuming the bugs are true before detection nothing would break.