### PR TITLE
Set `transition-behavior` in a constructed stylesheet

### DIFF
--- a/src/element-style-observer.js
+++ b/src/element-style-observer.js
@@ -91,7 +91,7 @@ export default class ElementStyleObserver {
 
 		this.renderedObserver = new RenderedObserver(records => {
 			// The element might be moved to another document or shadow root
-			this.targetMoved();
+			this.initRootNode();
 
 			if (this.propertyNames.length > 0) {
 				this.handleEvent();
@@ -114,7 +114,7 @@ export default class ElementStyleObserver {
 		let firstTime = this.constructor.all.get(this.target).size === 1;
 		this.updateTransition({ firstTime });
 
-		this.targetMoved();
+		this.initRootNode();
 
 		this.#initialized = true;
 	}
@@ -290,7 +290,7 @@ export default class ElementStyleObserver {
 	/**
 	 * Set (ones per root) CSS on an element's root node (document or shadow root).
 	 */
-	targetMoved () {
+	initRootNode () {
 		let root = this.target.getRootNode();
 		root = root.ownerDocument ?? root; // ensure root is always a document
 

--- a/src/element-style-observer.js
+++ b/src/element-style-observer.js
@@ -105,21 +105,21 @@ export default class ElementStyleObserver {
 		let firstTime = this.constructor.all.get(this.target).size === 1;
 		this.updateTransition({ firstTime });
 
-		this.#setTransitionBehavior(this.target.getRootNode());
+		this.#setTreeCSS(this.target.getRootNode());
 
 		this.#initialized = true;
 	}
 
 	/**
-	 * Set (ones per root) transition behavior on an element's root node (document or shadow root).
-	 * @param {Document|ShadowRoot} root - The root node to set transition behavior on.
+	 * Set (ones per root) CSS on an element's root node (document or shadow root).
+	 * @param {Document|ShadowRoot} root - The root node to set CSS on.
 	 */
-	#setTransitionBehavior (root) {
+	#setTreeCSS (root) {
 		if (this.constructor.rootNodes.has(root)) {
 			return;
 		}
 
-		// Set separately to maximize browser support
+		// Set separately from other transition properties to maximize browser support
 		adoptCSS("* { transition-behavior: allow-discrete !important }", root);
 		this.constructor.rootNodes.add(root);
 	}

--- a/src/element-style-observer.js
+++ b/src/element-style-observer.js
@@ -105,14 +105,7 @@ export default class ElementStyleObserver {
 		let firstTime = this.constructor.all.get(this.target).size === 1;
 		this.updateTransition({ firstTime });
 
-		// Initialize transition behavior for the main document
-		this.#setTransitionBehavior(this.target.ownerDocument);
-
-		// If the target is in a shadow root, initialize that too
-		let root = this.target.getRootNode();
-		if (root instanceof ShadowRoot) {
-			this.#setTransitionBehavior(root);
-		}
+		this.#setTransitionBehavior(this.target.getRootNode());
 
 		this.#initialized = true;
 	}

--- a/src/util/adopt-css.js
+++ b/src/util/adopt-css.js
@@ -4,7 +4,7 @@ let style;
  * @param {string} css
  */
 export default function adoptCSS (css, document = globalThis.document) {
-	let window = document.defaultView;
+	let window = document.defaultView ?? document.ownerDocument?.defaultView;
 	if (document.adoptedStyleSheets) {
 		let sheet = new window.CSSStyleSheet();
 		sheet.replaceSync(css);

--- a/src/util/adopt-css.js
+++ b/src/util/adopt-css.js
@@ -1,7 +1,9 @@
 let style;
 
 /**
- * @param {string} css
+ * Adopt CSS into a document or shadow root.
+ * @param {string} css - The CSS to adopt.
+ * @param {Document|ShadowRoot} [root=globalThis.document] - The document or shadow root to adopt the CSS into.
  */
 export default function adoptCSS (css, root = globalThis.document) {
 	// Ensure root is always a document

--- a/src/util/adopt-css.js
+++ b/src/util/adopt-css.js
@@ -4,7 +4,9 @@ let style;
  * @param {string} css
  */
 export default function adoptCSS (css, root = globalThis.document) {
-	let window = root.defaultView ?? root.ownerDocument?.defaultView;
+	// Ensure root is always a document
+	root = root.ownerDocument ?? root;
+	let window = root.defaultView;
 	if (root.adoptedStyleSheets) {
 		let sheet = new window.CSSStyleSheet();
 		sheet.replaceSync(css);

--- a/src/util/adopt-css.js
+++ b/src/util/adopt-css.js
@@ -3,21 +3,21 @@ let style;
 /**
  * @param {string} css
  */
-export default function adoptCSS (css, document = globalThis.document) {
-	let window = document.defaultView ?? document.ownerDocument?.defaultView;
-	if (document.adoptedStyleSheets) {
+export default function adoptCSS (css, root = globalThis.document) {
+	let window = root.defaultView ?? root.ownerDocument?.defaultView;
+	if (root.adoptedStyleSheets) {
 		let sheet = new window.CSSStyleSheet();
 		sheet.replaceSync(css);
 
-		if (Object.isFrozen(document.adoptedStyleSheets)) {
-			document.adoptedStyleSheets = [...document.adoptedStyleSheets, sheet];
+		if (Object.isFrozen(root.adoptedStyleSheets)) {
+			root.adoptedStyleSheets = [...root.adoptedStyleSheets, sheet];
 		}
 		else {
-			document.adoptedStyleSheets.push(sheet);
+			root.adoptedStyleSheets.push(sheet);
 		}
 	}
 	else {
-		style ??= document.head.appendChild(document.createElement("style"));
+		style ??= root.head.appendChild(root.createElement("style"));
 
 		style.insertAdjacentText("beforeend", css);
 	}


### PR DESCRIPTION
- Get rid of all useless (invalid) properties in the browser dev tools. Appeared after https://github.com/LeaVerou/style-observer/commit/e5de44d78269ded5bdd34efdde0d7a3b220aa3fd
- Allow adopting CSS in shadow roots.