### PR TITLE
Fix errors when using the package in a Next.js app

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "main": "index.js",
   "exports": {
     ".": {
-      "default": "./index.js",
-      "types": "./types/index.d.ts"
+      "types": "./types/index.d.ts",
+      "default": "./index.js"
     }
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "exports": {
     ".": {
-      "import": "./index.js",
+      "default": "./index.js",
       "types": "./types/index.d.ts"
     }
   },

--- a/src/element-style-observer.js
+++ b/src/element-style-observer.js
@@ -7,7 +7,7 @@ import RenderedObserver from "./rendered-observer.js";
 // We register this as non-inherited so that nested targets work as expected
 gentleRegisterProperty("--style-observer-transition", { inherits: false });
 
-const allowDiscrete = globalThis.CSS?.supports("transition-behavior", "allow-discrete")
+const allowDiscrete = globalThis.CSS?.supports?.("transition-behavior", "allow-discrete")
 	? " allow-discrete"
 	: "";
 

--- a/src/element-style-observer.js
+++ b/src/element-style-observer.js
@@ -7,7 +7,7 @@ import RenderedObserver from "./rendered-observer.js";
 // We register this as non-inherited so that nested targets work as expected
 gentleRegisterProperty("--style-observer-transition", { inherits: false });
 
-const allowDiscrete = CSS.supports("transition-behavior", "allow-discrete")
+const allowDiscrete = globalThis.CSS?.supports("transition-behavior", "allow-discrete")
 	? " allow-discrete"
 	: "";
 

--- a/src/util/detect-bugs/transitionrun-loop.js
+++ b/src/util/detect-bugs/transitionrun-loop.js
@@ -5,7 +5,7 @@ let document = globalThis.document;
 let dummy = document?.createElement("div");
 document?.body.appendChild(dummy);
 let property = "--bar-" + Date.now();
-dummy?.style.cssText = `${property}: 1; transition: ${property} 1ms step-start allow-discrete`;
+if (dummy) dummy.style.cssText = `${property}: 1; transition: ${property} 1ms step-start allow-discrete`;
 
 /**
  * Detect if the browser is affected by the Safari transition loop bug.
@@ -17,6 +17,6 @@ export default new Promise(resolve => {
 	requestAnimationFrame(() => {
 		setTimeout(_ => resolve(eventsCount > 1), 50);
 		dummy?.addEventListener("transitionrun", _ => eventsCount++);
-		dummy?.style.setProperty(property, "2");
+		dummy?.style?.setProperty(property, "2");
 	});
 }).finally(() => dummy?.remove());

--- a/src/util/detect-bugs/transitionrun-loop.js
+++ b/src/util/detect-bugs/transitionrun-loop.js
@@ -16,7 +16,7 @@ if (dummy) { // This should only be false if there's no DOM (e.g. in Node)
 export default new Promise(resolve => {
 	if (!dummy) return resolve(false);
 	let eventsCount = 0;
-	globalThis.requestAnimationFrame(() => {
+	requestAnimationFrame(() => {
 		setTimeout(_ => resolve(eventsCount > 1), 50);
 		dummy.addEventListener("transitionrun", _ => eventsCount++);
 		dummy.style.setProperty(property, "2");

--- a/src/util/detect-bugs/transitionrun-loop.js
+++ b/src/util/detect-bugs/transitionrun-loop.js
@@ -14,7 +14,7 @@ if (dummy) dummy.style.cssText = `${property}: 1; transition: ${property} 1ms st
  */
 export default new Promise(resolve => {
 	let eventsCount = 0;
-	requestAnimationFrame(() => {
+	globalThis.requestAnimationFrame?.(() => {
 		setTimeout(_ => resolve(eventsCount > 1), 50);
 		dummy?.addEventListener("transitionrun", _ => eventsCount++);
 		dummy?.style?.setProperty(property, "2");

--- a/src/util/detect-bugs/transitionrun-loop.js
+++ b/src/util/detect-bugs/transitionrun-loop.js
@@ -1,10 +1,8 @@
 // In Safari < 18.2, transitioning custom properties of syntax `*` or `<string>`
 // causes an infinite loop of `transitionrun` or `transitionstart` events.
 // We use this test to detect the bug.
-let document = globalThis.document;
-let dummy;
-if (document) {
-	dummy = document.createElement("div");
+let dummy = globalThis.document?.createElement("div");
+if (dummy) { // This should only be false if there's no DOM (e.g. in Node)
 	document.body.appendChild(dummy);
 	let property = "--bar-" + Date.now();
 	dummy.style.cssText = `${property}: 1; transition: ${property} 1ms step-start allow-discrete`;

--- a/src/util/detect-bugs/transitionrun-loop.js
+++ b/src/util/detect-bugs/transitionrun-loop.js
@@ -2,10 +2,13 @@
 // causes an infinite loop of `transitionrun` or `transitionstart` events.
 // We use this test to detect the bug.
 let document = globalThis.document;
-let dummy = document?.createElement("div");
-document?.body.appendChild(dummy);
-let property = "--bar-" + Date.now();
-if (dummy) dummy.style.cssText = `${property}: 1; transition: ${property} 1ms step-start allow-discrete`;
+let dummy;
+if (document) {
+	dummy = document.createElement("div");
+	document.body.appendChild(dummy);
+	let property = "--bar-" + Date.now();
+	dummy.style.cssText = `${property}: 1; transition: ${property} 1ms step-start allow-discrete`;
+}
 
 /**
  * Detect if the browser is affected by the Safari transition loop bug.
@@ -13,10 +16,11 @@ if (dummy) dummy.style.cssText = `${property}: 1; transition: ${property} 1ms st
  * @type {Promise<boolean>}
  */
 export default new Promise(resolve => {
+	if (!document) return resolve(false);
 	let eventsCount = 0;
-	globalThis.requestAnimationFrame?.(() => {
+	globalThis.requestAnimationFrame(() => {
 		setTimeout(_ => resolve(eventsCount > 1), 50);
-		dummy?.addEventListener("transitionrun", _ => eventsCount++);
-		dummy?.style?.setProperty(property, "2");
+		dummy.addEventListener("transitionrun", _ => eventsCount++);
+		dummy.style.setProperty(property, "2");
 	});
 }).finally(() => dummy?.remove());

--- a/src/util/detect-bugs/transitionrun-loop.js
+++ b/src/util/detect-bugs/transitionrun-loop.js
@@ -1,10 +1,11 @@
 // In Safari < 18.2, transitioning custom properties of syntax `*` or `<string>`
 // causes an infinite loop of `transitionrun` or `transitionstart` events.
 // We use this test to detect the bug.
-let dummy = document.createElement("div");
-document.body.appendChild(dummy);
+let document = globalThis.document;
+let dummy = document?.createElement("div");
+document?.body.appendChild(dummy);
 let property = "--bar-" + Date.now();
-dummy.style.cssText = `${property}: 1; transition: ${property} 1ms step-start allow-discrete`;
+dummy?.style.cssText = `${property}: 1; transition: ${property} 1ms step-start allow-discrete`;
 
 /**
  * Detect if the browser is affected by the Safari transition loop bug.
@@ -15,7 +16,7 @@ export default new Promise(resolve => {
 	let eventsCount = 0;
 	requestAnimationFrame(() => {
 		setTimeout(_ => resolve(eventsCount > 1), 50);
-		dummy.addEventListener("transitionrun", _ => eventsCount++);
-		dummy.style.setProperty(property, "2");
+		dummy?.addEventListener("transitionrun", _ => eventsCount++);
+		dummy?.style.setProperty(property, "2");
 	});
-}).finally(() => dummy.remove());
+}).finally(() => dummy?.remove());

--- a/src/util/detect-bugs/transitionrun-loop.js
+++ b/src/util/detect-bugs/transitionrun-loop.js
@@ -14,7 +14,7 @@ if (dummy) { // This should only be false if there's no DOM (e.g. in Node)
  * @type {Promise<boolean>}
  */
 export default new Promise(resolve => {
-	if (!document) return resolve(false);
+	if (!dummy) return resolve(false);
 	let eventsCount = 0;
 	globalThis.requestAnimationFrame(() => {
 		setTimeout(_ => resolve(eventsCount > 1), 50);

--- a/src/util/detect-bugs/unregistered-transition.js
+++ b/src/util/detect-bugs/unregistered-transition.js
@@ -1,8 +1,9 @@
 // Detect https://issues.chromium.org/issues/360159391
-let dummy = document.createElement("div");
-document.body.appendChild(dummy);
+let document = globalThis.document;
+let dummy = document?.createElement("div");
+document?.body.appendChild(dummy);
 let property = "--foo-" + Date.now();
-dummy.style.cssText = `${property}: 1; transition: ${property} 1ms step-start allow-discrete`;
+dummy?.style.cssText = `${property}: 1; transition: ${property} 1ms step-start allow-discrete`;
 
 /**
  * Detect if the browser is affected by the unregistered transition bug.
@@ -12,7 +13,7 @@ dummy.style.cssText = `${property}: 1; transition: ${property} 1ms step-start al
 export default new Promise(resolve => {
 	requestAnimationFrame(() => {
 		setTimeout(_ => resolve(true), 30);
-		dummy.addEventListener("transitionstart", _ => resolve(false));
-		dummy.style.setProperty(property, "2");
+		dummy?.addEventListener("transitionstart", _ => resolve(false));
+		dummy?.style.setProperty(property, "2");
 	});
-}).finally(_ => dummy.remove());
+}).finally(_ => dummy?.remove());

--- a/src/util/detect-bugs/unregistered-transition.js
+++ b/src/util/detect-bugs/unregistered-transition.js
@@ -3,7 +3,7 @@ let document = globalThis.document;
 let dummy = document?.createElement("div");
 document?.body.appendChild(dummy);
 let property = "--foo-" + Date.now();
-dummy?.style.cssText = `${property}: 1; transition: ${property} 1ms step-start allow-discrete`;
+if (dummy) dummy.style.cssText = `${property}: 1; transition: ${property} 1ms step-start allow-discrete`;
 
 /**
  * Detect if the browser is affected by the unregistered transition bug.
@@ -14,6 +14,6 @@ export default new Promise(resolve => {
 	requestAnimationFrame(() => {
 		setTimeout(_ => resolve(true), 30);
 		dummy?.addEventListener("transitionstart", _ => resolve(false));
-		dummy?.style.setProperty(property, "2");
+		dummy?.style?.setProperty(property, "2");
 	});
 }).finally(_ => dummy?.remove());

--- a/src/util/detect-bugs/unregistered-transition.js
+++ b/src/util/detect-bugs/unregistered-transition.js
@@ -1,9 +1,12 @@
 // Detect https://issues.chromium.org/issues/360159391
 let document = globalThis.document;
-let dummy = document?.createElement("div");
-document?.body.appendChild(dummy);
-let property = "--foo-" + Date.now();
-if (dummy) dummy.style.cssText = `${property}: 1; transition: ${property} 1ms step-start allow-discrete`;
+let dummy;
+if (document) {
+	dummy = document.createElement("div");
+	document.body.appendChild(dummy);
+	let property = "--foo-" + Date.now();
+	dummy.style.cssText = `${property}: 1; transition: ${property} 1ms step-start allow-discrete`;
+}
 
 /**
  * Detect if the browser is affected by the unregistered transition bug.
@@ -11,9 +14,10 @@ if (dummy) dummy.style.cssText = `${property}: 1; transition: ${property} 1ms st
  * @type {Promise<boolean>}
  */
 export default new Promise(resolve => {
-	globalThis.requestAnimationFrame?.(() => {
+	if (!document) return resolve(false);
+	globalThis.requestAnimationFrame(() => {
 		setTimeout(_ => resolve(true), 30);
-		dummy?.addEventListener("transitionstart", _ => resolve(false));
-		dummy?.style?.setProperty(property, "2");
+		dummy.addEventListener("transitionstart", _ => resolve(false));
+		dummy.style.setProperty(property, "2");
 	});
 }).finally(_ => dummy?.remove());

--- a/src/util/detect-bugs/unregistered-transition.js
+++ b/src/util/detect-bugs/unregistered-transition.js
@@ -11,7 +11,7 @@ if (dummy) dummy.style.cssText = `${property}: 1; transition: ${property} 1ms st
  * @type {Promise<boolean>}
  */
 export default new Promise(resolve => {
-	requestAnimationFrame(() => {
+	globalThis.requestAnimationFrame?.(() => {
 		setTimeout(_ => resolve(true), 30);
 		dummy?.addEventListener("transitionstart", _ => resolve(false));
 		dummy?.style?.setProperty(property, "2");

--- a/src/util/detect-bugs/unregistered-transition.js
+++ b/src/util/detect-bugs/unregistered-transition.js
@@ -1,8 +1,6 @@
 // Detect https://issues.chromium.org/issues/360159391
-let document = globalThis.document;
-let dummy;
-if (document) {
-	dummy = document.createElement("div");
+let dummy = globalThis.document?.createElement("div");
+if (dummy) { // This should only be false if there's no DOM (e.g. in Node)
 	document.body.appendChild(dummy);
 	let property = "--foo-" + Date.now();
 	dummy.style.cssText = `${property}: 1; transition: ${property} 1ms step-start allow-discrete`;
@@ -14,8 +12,8 @@ if (document) {
  * @type {Promise<boolean>}
  */
 export default new Promise(resolve => {
-	if (!document) return resolve(false);
-	globalThis.requestAnimationFrame(() => {
+	if (!dummy) return resolve(false);
+	requestAnimationFrame(() => {
 		setTimeout(_ => resolve(true), 30);
 		dummy.addEventListener("transitionstart", _ => resolve(false));
 		dummy.style.setProperty(property, "2");

--- a/src/util/gentle-register-property.js
+++ b/src/util/gentle-register-property.js
@@ -31,7 +31,7 @@ export default function gentleRegisterProperty (property, meta = {}, window = gl
 
 	if (
 		!property.startsWith("--") ||
-		!CSS.registerProperty ||
+		!CSS?.registerProperty ||
 		isRegisteredProperty(property, window)
 	) {
 		return;

--- a/src/util/gentle-register-property.js
+++ b/src/util/gentle-register-property.js
@@ -25,13 +25,12 @@ const INITIAL_VALUES = {
  * @param {string} [meta.syntax] - Property syntax.
  * @param {boolean} [meta.inherits] - Whether the property inherits.
  * @param {*} [meta.initialValue] - Initial value.
+ * @param {Window} [window] - The window to check in.
  */
 export default function gentleRegisterProperty (property, meta = {}, window = globalThis) {
-	let CSS = window.CSS;
-
 	if (
 		!property.startsWith("--") ||
-		!CSS?.registerProperty ||
+		!window.CSS?.registerProperty ||
 		isRegisteredProperty(property, window)
 	) {
 		return;
@@ -51,7 +50,7 @@ export default function gentleRegisterProperty (property, meta = {}, window = gl
 	}
 
 	try {
-		CSS.registerProperty(definition);
+		window.CSS.registerProperty(definition);
 	}
 	catch (e) {
 		let error = e;
@@ -71,7 +70,7 @@ export default function gentleRegisterProperty (property, meta = {}, window = gl
 				definition.syntax = "*";
 
 				try {
-					CSS.registerProperty(definition);
+					window.CSS.registerProperty(definition);
 					rethrow = false;
 				}
 				catch (e) {

--- a/tests/util/gentle-register-property.js
+++ b/tests/util/gentle-register-property.js
@@ -6,15 +6,16 @@
  * @param {string} [meta.syntax] - Property syntax.
  * @param {boolean} [meta.inherits] - Whether the property inherits.
  * @param {*} [meta.initialValue] - Initial value.
+ * @param {Window} [window] - The window to check in.
  * @returns {boolean} - Whether the property was successfully registered.
  */
-export default function gentleRegisterProperty (property, meta = {}, global = globalThis) {
-	if (!property.startsWith("--") || !global.CSS?.registerProperty) {
+export default function gentleRegisterProperty (property, meta = {}, window = globalThis) {
+	if (!property.startsWith("--") || !window.CSS?.registerProperty) {
 		return false;
 	}
 
 	try {
-		global.CSS.registerProperty({
+		window.CSS.registerProperty({
 			name: property,
 			inherits: meta.inherits ?? true,
 			syntax: meta.syntax,


### PR DESCRIPTION
This fixes the following errors I was getting when building my Next.js app that uses this package:

1. Changed package.json's `"exports"` field's `"import"` to `"default"` so it works in CJS module resolution as well as ESM (note: `"default"` _has_ to be defined last):

```
my-app:build: Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: No "exports" main defined in /Users/benface/my-app/node_modules/style-observer/package.json
my-app:build:     at exportsNotFound (node:internal/modules/esm/resolve:314:10)
my-app:build:     at packageExportsResolve (node:internal/modules/esm/resolve:604:13)
my-app:build:     at resolveExports (node:internal/modules/cjs/loader:657:36)
my-app:build:     at Function._findPath (node:internal/modules/cjs/loader:749:31)
my-app:build:     at Function.<anonymous> (node:internal/modules/cjs/loader:1387:27)
my-app:build:     at /Users/benface/my-app/node_modules/.pnpm/next@14.2.28_@babel+core@7.27.1_react-dom@18.3.1_react@18.3.1__react@18.3.1/node_modules/next/dist/server/require-hook.js:55:36
```

2. Made sure referencing `document`, `requestAnimationFrame`, and `window.CSS` doesn't error when the code happens to run in Node, i.e. during SSR:

```
my-app:build: ReferenceError: document is not defined
my-app:build:     at /Users/benface/my-app/node_modules/style-observer/src/util/detect-bugs/transitionrun-loop.js:4:13
```