### PR TITLE
Another attempt to fix TS overloads, fixes #114

### DIFF
--- a/src/style-observer.js
+++ b/src/style-observer.js
@@ -52,15 +52,16 @@ export default class StyleObserver {
 	 * @overload
 	 * @param {Element | Element[]} targets
 	 * @param {string | string[]} properties
+	 * @returns {void}
 	 *
 	 * @overload
 	 * @param {string | string[]} properties
 	 * @param {Element | Element[]} targets
+	 * @returns {void}
 	 *
 	 * @overload
 	 * @param {...(string | Element | (string | Element)[]) } propertiesOrTargets
-
-	 * @return {void}
+	 * @returns {void}
 	 */
 	observe (...args) {
 		let { targets, properties } = resolveArgs(...args);
@@ -96,15 +97,16 @@ export default class StyleObserver {
 	 * @overload
 	 * @param {Element | Element[]} targets
 	 * @param {string | string[]} properties
+	 * @returns {void}
 	 *
 	 * @overload
 	 * @param {string | string[]} properties
 	 * @param {Element | Element[]} targets
+	 * @returns {void}
 	 *
 	 * @overload
 	 * @param {...(string | Element | (string | Element)[]) } propertiesOrTargets
-	 *
-	 * @return {void}
+	 * @returns {void}
 	 */
 	unobserve (...args) {
 		let { targets, properties } = resolveArgs(...args);

--- a/src/style-observer.js
+++ b/src/style-observer.js
@@ -48,6 +48,8 @@ export default class StyleObserver {
 
 	/**
 	 * Observe one or more targets for changes to one or more CSS properties.
+	 *
+	 * @overload
 	 * @param {Element | Element[]} targets
 	 * @param {string | string[]} properties
 	 *
@@ -90,12 +92,18 @@ export default class StyleObserver {
 
 	/**
 	 * Stop observing one or more targets for changes to one or more CSS properties.
+	 *
+	 * @overload
 	 * @param {Element | Element[]} targets
 	 * @param {string | string[]} properties
 	 *
 	 * @overload
 	 * @param {string | string[]} properties
 	 * @param {Element | Element[]} targets
+	 *
+	 * @overload
+	 * @param {...(string | Element | (string | Element)[]) } propertiesOrTargets
+	 *
 	 * @return {void}
 	 */
 	unobserve (...args) {


### PR DESCRIPTION
To make TS correctly pick all possible overloads, we need to mark _every_ signature with `@overload`.