### PR TITLE
Add default export condition to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     ".": {
       "import": "./index.js",
       "require": "./index.js",
-      "types": "./types/index.d.ts"
+      "types": "./types/index.d.ts",
+      "default": "./index.js"
     }
   },
   "scripts": {


### PR DESCRIPTION
In one of [our projects](https://github.com/vaadin/bundles/pull/156) we are using webpack build with the following config:

```js
export default {
  mode: 'development',
  resolve: {
    conditionNames: ['development']
  },
  // ...
}
```

This currently causes an error when importing `style-observer`:

```
Module not found: Error: Package path . is not exported from package /Users/serhii/vaadin/bundles/node_modules/style-observer (see exports field in /Users/serhii/vaadin/bundles/node_modules/style-observer/package.json)
```

We figured out it's because the `default` condition is missing. Adding it manually fixes this error.
For now we had to workaround by changing to use `conditionNames: ['development', 'import']`