### PR TITLE
Refactor `gentleRegisterProperty`

### DIFF
--- a/src/element-style-observer.js
+++ b/src/element-style-observer.js
@@ -190,7 +190,7 @@ export default class ElementStyleObserver {
 		for (let property of properties) {
 			if (bugs.UNREGISTERED_TRANSITION && !this.constructor.properties.has(property)) {
 				// Init property
-				gentleRegisterProperty(property, undefined, this.target.ownerDocument.defaultView);
+				gentleRegisterProperty(property, undefined, this.target.ownerDocument);
 				this.constructor.properties.add(property);
 			}
 

--- a/src/util/gentle-register-property.js
+++ b/src/util/gentle-register-property.js
@@ -1,4 +1,5 @@
 import adoptCSS from "./adopt-css.js";
+import isRegisteredProperty from "./is-registered-property.js";
 
 const INITIAL_VALUES = {
 	"<angle>": "0deg",
@@ -25,18 +26,22 @@ const INITIAL_VALUES = {
 let properties = new Map();
 
 /**
- * Register a CSS custom property.
+ * Register a CSS custom property if it’s not already registered.
  * @param {string} property - Property name.
  * @param {Object} [meta] - Property definition.
  * @param {string} [meta.syntax] - Property syntax.
  * @param {boolean} [meta.inherits] - Whether the property inherits.
  * @param {*} [meta.initialValue] - Initial value.
- * @param {Document} [root] - Document to register the property in.
+ * @param {Document} [root=globalThis.document] - Document to register the property in.
  */
 export default function gentleRegisterProperty (property, meta = {}, root = globalThis.document) {
 	let registeredProperties = properties.get(root);
 
-	if (!property.startsWith("--") || (registeredProperties && property in registeredProperties)) {
+	if (
+		!property.startsWith("--") || 
+		(registeredProperties && property in registeredProperties) || 
+		isRegisteredProperty(property, root)
+	) {
 		return;
 	}
 

--- a/src/util/gentle-register-property.js
+++ b/src/util/gentle-register-property.js
@@ -67,3 +67,34 @@ export default function gentleRegisterProperty (property, meta = {}, root = glob
 
 	registeredProperties[property] = styleSheet;
 }
+
+/**
+ * Unregister a CSS custom property if it was registered with `gentleRegisterProperty`.
+ * @param {string} property - Property name.
+ * @param {Document} [root=globalThis.document] - Document to unregister the property from.
+ */
+export function unregisterProperty (property, root = globalThis.document) {
+	let registeredProperties = properties.get(root);
+
+	if (!registeredProperties || !(property in registeredProperties)) {
+		return;
+	}
+
+	let styleSheet = registeredProperties[property];
+	if (root.adoptedStyleSheets) {
+		root.adoptedStyleSheets = root.adoptedStyleSheets.filter(sheet => sheet !== styleSheet);
+	}
+	else {
+		// Find the rule corresponding to the property and remove it
+		let rules = styleSheet.cssRules;
+		for (let i = 0; i < rules.length; i++) {
+			let rule = rules[i].cssRules[0];
+			if (rule.name === property) {
+				styleSheet.deleteRule(i);
+				break;
+			}
+		}
+	}
+
+	delete registeredProperties[property];
+}

--- a/src/util/is-registered-property.js
+++ b/src/util/is-registered-property.js
@@ -2,14 +2,12 @@
  * Check if a CSS custom property is registered.
  * This function will return `false` for custom properties that behave identically to non-registered properties (e.g., registered inherited properties with syntax "*").
  * @param {string} property - The property to check.
- * @param {Window} [window] - The window to check in.
+ * @param {Document} [root=globalThis.document] - The document to check in.
  * @returns {boolean}
  */
-export default function isRegisteredProperty (property, window = globalThis) {
-	let document = window.document;
-
-	let dummy = document.createElement("div");
-	document.body.append(dummy);
+export default function isRegisteredProperty (property, root = globalThis.document) {
+	let dummy = root.createElement("div");
+	root.body.append(dummy);
 
 	let invalidValue = "foo(bar)"; // a value that is invalid for any registered syntax
 	dummy.style.setProperty(property, invalidValue);
@@ -20,7 +18,7 @@ export default function isRegisteredProperty (property, window = globalThis) {
 		// We might have either unregistered or registered custom property with syntax "*".
 		// If it's non-inherited, we can be sure it's registered.
 		// But if it's inherited, it's OK if we (re-)register it with syntax "*" in any case.
-		let child = dummy.appendChild(document.createElement("div"));
+		let child = dummy.appendChild(root.createElement("div"));
 		let inheritedValue = getComputedStyle(child).getPropertyValue(property);
 		ret = inheritedValue !== invalidValue;
 	}

--- a/tests/reflow.js
+++ b/tests/reflow.js
@@ -68,9 +68,9 @@ export default {
 			reflowObserver.disconnect();
 		});
 
-		setTimeout(() => {
+		requestAnimationFrame(() => {
 			target.style.setProperty(property, value);
-		}, 50);
+		});
 
 		return Promise.all([reflowPromise, stylePromise]).then(([reflow, change]) => reflow);
 	},


### PR DESCRIPTION
- Register properties by placing the corresponding `@property` rules in a CSS layer instead of less permissive `CSS.registerProperty`. The user’s rules now have higher priority, and they can redefine already registered properties if needed.
- [tests] Fix race conditions in the reflow tests