### PR TITLE
An attempt to fix #138

### DIFF
--- a/src/util/is-registered-property.js
+++ b/src/util/is-registered-property.js
@@ -7,7 +7,8 @@
  */
 export default function isRegisteredProperty (property, root = globalThis.document) {
 	let dummy = root.createElement("div");
-	root.head.append(dummy);
+	const container = root.body ?? root.head;
+	container.append(dummy);
 
 	let invalidValue = "foo(bar)"; // a value that is invalid for any registered syntax
 	dummy.style.setProperty(property, invalidValue);

--- a/src/util/is-registered-property.js
+++ b/src/util/is-registered-property.js
@@ -7,7 +7,7 @@
  */
 export default function isRegisteredProperty (property, root = globalThis.document) {
 	let dummy = root.createElement("div");
-	root.body.append(dummy);
+	root.head.append(dummy);
 
 	let invalidValue = "foo(bar)"; // a value that is invalid for any registered syntax
 	dummy.style.setProperty(property, invalidValue);


### PR DESCRIPTION
In `isRegisteredProperty`, append a dummy element to `document.head` instead of `document.body` to avoid issues when `document.body` is not yet accessible and is `null`—proposed by @LeaVerou.